### PR TITLE
Enforce HTTPS routing and secure asset loading

### DIFF
--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Http\Middleware\TrustProxies as Middleware;
+use Illuminate\Http\Request;
+
+class TrustProxies extends Middleware
+{
+    /**
+     * The trusted proxies for this application.
+     *
+     * Using "*" trusts all proxies so HTTPS headers like X-Forwarded-Proto
+     * are honored in load-balanced environments. Adjust as needed.
+     */
+    protected $proxies = '*';
+
+    /**
+     * The headers that should be used to detect proxies.
+     */
+    protected $headers = Request::HEADER_X_FORWARDED_ALL;
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +20,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        if (config('app.force_https') || $this->app->environment('production')) {
+            URL::forceScheme('https');
+        }
     }
 }

--- a/config/app.php
+++ b/config/app.php
@@ -54,6 +54,8 @@ return [
 
     'url' => env('APP_URL', 'http://localhost'),
 
+    'force_https' => env('FORCE_HTTPS', false),
+
     /*
     |--------------------------------------------------------------------------
     | Application Timezone

--- a/resources/views/adotar.blade.php
+++ b/resources/views/adotar.blade.php
@@ -181,7 +181,7 @@
 
                 <div class="col-md-3 col-sm-6 mb-4">
                     <div class="card pet-card">
-                        <img src="{{ asset('storage/images/' . $pet->imagem_url) }}" class="card-img-top"
+                        <img src="{{ secure_asset('storage/images/' . $pet->imagem_url) }}" class="card-img-top"
                             alt="{{ $pet->nome }}">
 
                         <div class="card-body text-start">
@@ -199,10 +199,10 @@
                                         @endif
                                     </p>
                                     @if($generoLower === 'macho')
-                                        <img src="{{ asset('storage/images/macho.png') }}" alt="Macho"
+                                        <img src="{{ secure_asset('storage/images/macho.png') }}" alt="Macho"
                                             class="pet-gender-icon pet-gender-macho">
                                     @elseif($generoLower === 'femea')
-                                        <img src="{{ asset('storage/images/femea.png') }}" alt="Fêmea"
+                                        <img src="{{ secure_asset('storage/images/femea.png') }}" alt="Fêmea"
                                             class="pet-gender-icon pet-gender-femea">
                                     @endif
                                 </div>

--- a/resources/views/cadastro.blade.php
+++ b/resources/views/cadastro.blade.php
@@ -154,9 +154,9 @@
 {{-- scripts iguais aos do login --}}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.mask/1.14.16/jquery.mask.min.js"></script>
-<script src="{{ asset('js/validarCpf.js') }}"></script>
-<script src="{{ asset('js/cepAutoComplete.js') }}"></script>
-<script src="{{ asset('js/cidadesEstados.js') }}"></script>
+<script src="{{ secure_asset('js/validarCpf.js') }}"></script>
+<script src="{{ secure_asset('js/cepAutoComplete.js') }}"></script>
+<script src="{{ secure_asset('js/cidadesEstados.js') }}"></script>
 
 <script>
     $(function () {

--- a/resources/views/cadastroAnimal.blade.php
+++ b/resources/views/cadastroAnimal.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.main')
 
 @section('head')
-<link rel="stylesheet" href="{{ asset('css/styleCadastro.css') }}">
+<link rel="stylesheet" href="{{ secure_asset('css/styleCadastro.css') }}">
 @endsection
 
 @section('menu')

--- a/resources/views/layouts/sidebarpainelong.blade.php
+++ b/resources/views/layouts/sidebarpainelong.blade.php
@@ -15,7 +15,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
 
   <!-- CSS custom -->
-  <link rel="stylesheet" href="{{ asset('css/styles.css') }}">
+  <link rel="stylesheet" href="{{ secure_asset('css/styles.css') }}">
 
   @yield('head')
   <style>

--- a/resources/views/painel/ong/pets.blade.php
+++ b/resources/views/painel/ong/pets.blade.php
@@ -57,7 +57,7 @@
                             'table-danger'  => $pet->status == 'adotado',
                         ])>
                             <td style="width: 80px">
-                                <img src="{{ asset('storage/images/' . $pet->imagem_url) }}" 
+                                <img src="{{ secure_asset('storage/images/' . $pet->imagem_url) }}"
                                      width="70" class="rounded shadow-sm" alt="Foto do pet">
                             </td>
                             <td>{{ $pet->nome }}</td>

--- a/resources/views/pets/adotarCachorro.blade.php
+++ b/resources/views/pets/adotarCachorro.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.main')
 
 @section('head')
-    <link rel="stylesheet" href="{{ asset('css/styleCadastro.css') }}">
+    <link rel="stylesheet" href="{{ secure_asset('css/styleCadastro.css') }}">
 @endsection
 
 @section('menu')
@@ -54,7 +54,7 @@
 
                 <div class="col-md-4 mb-4">
                     <div class="card h-100 shadow-sm">
-                        <img src="{{ asset('storage/images/' . $pet->imagem_url) }}"
+                        <img src="{{ secure_asset('storage/images/' . $pet->imagem_url) }}"
                              class="card-img-top"
                              style="height: 15rem; object-fit: cover; width: 100%;"
                              alt="{{ $pet->nome }}">

--- a/resources/views/pets/adotarGato.blade.php
+++ b/resources/views/pets/adotarGato.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.main')
 
 @section('head')
-    <link rel="stylesheet" href="{{ asset('css/styleCadastro.css') }}">
+    <link rel="stylesheet" href="{{ secure_asset('css/styleCadastro.css') }}">
 @endsection
 
 @section('menu')
@@ -54,7 +54,7 @@
 
                 <div class="col-md-4 mb-4">
                     <div class="card h-100 shadow-sm">
-                        <img src="{{ asset('storage/images/' . $pet->imagem_url) }}"
+                        <img src="{{ secure_asset('storage/images/' . $pet->imagem_url) }}"
                              class="card-img-top"
                              style="height: 15rem; object-fit: cover; width: 100%;"
                              alt="{{ $pet->nome }}">

--- a/resources/views/pets/mostrar.blade.php
+++ b/resources/views/pets/mostrar.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.main')
 
 @section('head')
-    <link rel="stylesheet" href="{{ asset('css/styleCadastro.css') }}">
+    <link rel="stylesheet" href="{{ secure_asset('css/styleCadastro.css') }}">
     <style>
         #container-principal-mostrar {
             padding-top: 6rem;
@@ -52,7 +52,7 @@
             <div class="col-md-6">
                 @php
                     $src = $pet->imagem_url
-                        ? asset('storage/images/' . ltrim($pet->imagem_url, '/'))
+                        ? secure_asset('storage/images/' . ltrim($pet->imagem_url, '/'))
                         : null;
                 @endphp
 

--- a/resources/views/resultado_match.blade.php
+++ b/resources/views/resultado_match.blade.php
@@ -24,7 +24,7 @@
 
       @php
         $img = $pet->imagem_url
-            ? asset('storage/images/' . ltrim($pet->imagem_url, '/'))
+            ? secure_asset('storage/images/' . ltrim($pet->imagem_url, '/'))
             : 'https://placehold.co/200x200?text=Pet';
       @endphp
 


### PR DESCRIPTION
## Summary
- force HTTPS scheme through proxy-aware middleware and service provider configuration
- add a FORCE_HTTPS flag to generate secure URLs when deploying over TLS
- use secure_asset helpers for site styles, scripts, and stored images to prevent mixed content

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a2c4745688332bd75ccc54b00d3f0)