### PR TITLE
Exibir solicitações no painel do adotante

### DIFF
--- a/app/Http/Controllers/AdotanteAuthController.php
+++ b/app/Http/Controllers/AdotanteAuthController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use App\Models\Pet;
+use App\Models\Solicitacao;
 
 
 class AdotanteAuthController extends Controller
@@ -41,8 +41,12 @@ class AdotanteAuthController extends Controller
     public function painelAdotante()
     {
         $adotante = Auth::guard('adotante')->user();
-        $pets = Pet::where('adotante_id', $adotante->id)->get();
-        return view('painelAdotante', compact('pets'));
+        $solicitacoes = Solicitacao::with('pet')
+            ->where('adotante_id', $adotante->id)
+            ->orderByDesc('created_at')
+            ->get();
+
+        return view('painelAdotante', compact('solicitacoes'));
     }
 
     public function logout(Request $request)

--- a/resources/views/painelAdotante.blade.php
+++ b/resources/views/painelAdotante.blade.php
@@ -1,93 +1,73 @@
 @extends ('layouts.main')
 
 @section('head')
+    <style>
+        body {
+            font-family: 'Segoe UI', sans-serif;
+        }
+    </style>
 @endsection
 
-@section('menu')
-@endsection
+@section('content')
+    <div class="py-4">
+        <h2 class="fw-semibold">Meus pedidos de adoção</h2>
 
+        <div class="table-responsive mt-4">
+            <table class="table table-bordered table-striped align-middle">
+                <thead class="table-dark">
+                    <tr>
+                        <th>Imagem</th>
+                        <th>Nome</th>
+                        <th>Raça</th>
+                        <th>Localização</th>
+                        <th>Status</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @forelse ($solicitacoes as $solicitacao)
+                        @php
+                            $pet = $solicitacao->pet;
 
-  <style>
-    body {
-      font-family: 'Segoe UI', sans-serif;
-    }
-    .sidebar {
-      height: 100vh;
-      background-color: #343a40;
-      color: white;
-      padding-top: 1rem;
-      min-width: 250px;
-    }
-    .sidebar a {
-      color: #adb5bd;
-      text-decoration: none;
-    }
-    .sidebar a:hover,
-    .sidebar .active {
-      background-color: #0d6efd;
-      color: white !important;
-    }
-    .sidebar .logo {
-      text-align: center;
-      margin-bottom: 20px;
-    }
-    .sidebar .logo img {
-      width: 120px;
-    }
-  </style>
-</head>
-    <!-- CONTEÚDO PRINCIPAL -->
-    <div class="p-4 flex-grow-1">
-      <h2>Pets Reservados</h2>
+                            $imagem = 'https://placehold.co/120x120?text=Pet';
+                            if ($pet && $pet->imagem_url) {
+                                $path = trim($pet->imagem_url);
+                                if (preg_match('#^(https?:)?//#', $path) || str_starts_with($path, 'data:')) {
+                                    $imagem = $path;
+                                } else {
+                                    $clean = ltrim($path, '/');
+                                    if (!str_contains($clean, '/')) {
+                                        $clean = 'images/' . $clean;
+                                    }
+                                    $imagem = str_starts_with($clean, 'storage/') ? asset($clean) : asset('storage/' . $clean);
+                                }
+                            }
 
-      <div class="table-responsive mt-4">
-        <table class="table table-bordered table-striped align-middle">
-          <thead class="table-dark">
-            <tr>
-              <th>Imagem</th>
-              <th>Nome</th>
-              <th>Raça</th>
-              <th>Localização</th>
-              <th>Status</th>
-              <th>Ação</th>
-            </tr>
-          </thead>
-          <tbody>
-            <!-- Exemplo de pet reservado -->
-            <tr>
-              <td><img src="/images/pet1.jpg" alt="Pet 1" width="100" /></td>
-              <td>Bolinha</td>
-              <td>Vira-lata</td>
-              <td>São Paulo - SP</td>
-              <td>Reservado</td>
-              <td><button class="btn btn-primary btn-sm">Entrar em contato com a ONG</button></td>
-            </tr>
+                            $status = $solicitacao->status ?? 'novo';
+                            $statusInfo = [
+                                'novo' => ['label' => 'Aguarde a ONG entrar em contato', 'class' => 'bg-warning text-dark'],
+                                'aprovado' => ['label' => 'Adotado', 'class' => 'bg-success'],
+                                'recusado' => ['label' => 'Recusado', 'class' => 'bg-danger'],
+                            ][$status] ?? ['label' => ucfirst($status), 'class' => 'bg-secondary'];
+                        @endphp
 
-            <!-- Exemplo de pet pendente -->
-            <tr>
-              <td><img src="/images/pet2.jpg" alt="Pet 2" width="100" /></td>
-              <td>Mel</td>
-              <td>Poodle</td>
-              <td>Campinas - SP</td>
-              <td>Pendente</td>
-              <td><span class="badge bg-warning text-dark">Pendente</span></td>
-            </tr>
-
-            <!-- Exemplo de pet adotado -->
-            <tr>
-              <td><img src="/images/pet3.jpg" alt="Pet 3" width="100" /></td>
-              <td>Rex</td>
-              <td>Golden Retriever</td>
-              <td>Ribeirão Preto - SP</td>
-              <td>Adotado</td>
-              <td><span class="badge bg-success">Adotado</span></td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+                        <tr>
+                            <td>
+                                <img src="{{ $imagem }}" alt="Foto do pet" width="120" class="rounded">
+                            </td>
+                            <td>{{ $pet->nome ?? '—' }}</td>
+                            <td>{{ $pet->raca ?? '—' }}</td>
+                            <td>{{ $pet->localizacao ?? '—' }}</td>
+                            <td>
+                                <span class="badge {{ $statusInfo['class'] }}">{{ $statusInfo['label'] }}</span>
+                            </td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="5" class="text-center py-4">Você ainda não solicitou a adoção de nenhum pet.</td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
     </div>
-  </div>
-
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-</body>
-</html>
+@endsection


### PR DESCRIPTION
## Summary
- carregar e exibir as solicitações de adoção do adotante logado com dados do pet
- mostrar status amigável (aguarde, adotado, recusado) para cada solicitação
- ajustar layout do painel para usar a estrutura principal do site

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69237bf7743c83328e15afc4697920e6)