### PR TITLE
Add adoption confirmation modal and redirect handling

### DIFF
--- a/app/Http/Controllers/LoginController.php
+++ b/app/Http/Controllers/LoginController.php
@@ -10,8 +10,12 @@ use App\Models\Ong;
 
 class LoginController extends Controller
 {
-    public function showLoginForm()
+    public function showLoginForm(Request $request)
     {
+        if ($request->filled('redirect')) {
+            session(['url.intended' => $request->redirect]);
+        }
+
         return view('login');
     }
 

--- a/resources/views/pets/mostrar.blade.php
+++ b/resources/views/pets/mostrar.blade.php
@@ -146,11 +146,12 @@
                     @endphp
 
                     @auth('adotante')
-                        <form method="POST" action="{{ route('solicitacoes.store') }}" class="d-grid gap-2">
+                        <form method="POST" action="{{ route('solicitacoes.store') }}" class="d-grid gap-2" id="formSolicitacaoAdocao">
                             @csrf
                             <input type="hidden" name="pet_id" value="{{ $pet->id }}">
 
-                            <button type="submit" class="btn btn-primary w-100 fw-bold" {{ $desabilitar ? 'disabled' : '' }}>
+                            <button type="button" class="btn btn-primary w-100 fw-bold" data-bs-toggle="modal"
+                                    data-bs-target="#confirmarAdocaoModal" {{ $desabilitar ? 'disabled' : '' }}>
                                 Quero Adotar!
                             </button>
                         </form>
@@ -170,7 +171,42 @@
             <p>{{ $pet->descricao ?? 'Sem história informada.' }}</p>
         </div>
     </div>
-    
+
+    @auth('adotante')
+        <div class="modal fade" id="confirmarAdocaoModal" tabindex="-1" aria-labelledby="confirmarAdocaoModalLabel" aria-hidden="true">
+            <div class="modal-dialog modal-dialog-centered">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="confirmarAdocaoModalLabel">Confirmar solicitação de adoção</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <p class="mb-3">Sua solicitação será enviada para a ONG responsável. Ela entrará em contato assim que receber o pedido.</p>
+                        <p class="mb-3">O processo passará por análise e você poderá ser convidado para uma conversa antes da aprovação.</p>
+                        <p class="fw-semibold mb-0">Tem certeza de que deseja adotar {{ $pet->nome }}?</p>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
+                        <button type="button" class="btn btn-primary" id="confirmarEnvioSolicitacao">Enviar solicitação</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <script>
+            document.addEventListener('DOMContentLoaded', function () {
+                var botaoConfirmar = document.getElementById('confirmarEnvioSolicitacao');
+                var formularioSolicitacao = document.getElementById('formSolicitacaoAdocao');
+
+                if (botaoConfirmar && formularioSolicitacao) {
+                    botaoConfirmar.addEventListener('click', function () {
+                        formularioSolicitacao.submit();
+                    });
+                }
+            });
+        </script>
+    @endauth
+
     @if(session('success') || session('error'))
   <div class="toast-container position-fixed top-0 start-50 translate-middle-x p-3" style="z-index:1080">
 


### PR DESCRIPTION
## Summary
- add a confirmation modal before sending adoption requests, explaining the review process and NGO contact
- keep the adoption request form submission intact while requiring explicit confirmation
- store a provided redirect URL when opening the login page so adopters return to the pet they were viewing

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923a1cdb7e88332a7fc5b3d6fdfadb0)