### PR TITLE
Fix footer positioning without affecting view layouts

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -7,7 +7,16 @@ body {
     background-repeat: repeat; /* Faz o padrão se repetir em todas as direções */
     background-size: auto; /* Deixa o tamanho original da imagem */
     background-position: top left; /* Começa a repetição no canto superior esquerdo */
-    font-family: 'Poppins', sans-serif;  
+    font-family: 'Poppins', sans-serif;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+.main-content {
+    padding-top: 96px; /* compensa a navbar fixa */
+    padding-bottom: 40px;
+    flex: 1;
 }
 
 

--- a/resources/views/layouts/main.blade.php
+++ b/resources/views/layouts/main.blade.php
@@ -31,7 +31,7 @@
 
 </head>
 
-<body>
+<body class="d-flex flex-column min-vh-100">
     <!-- Navbar -->
 
     <nav class="navbar navbar-expand-lg navbar-light custom-navbar">
@@ -115,12 +115,14 @@
     </nav>
 
     <!-- Conteúdo da página -->
-    <div class="container mt-4">
-        @yield('content')
-    </div>
+    <main class="main-content flex-fill">
+        <div class="container">
+            @yield('content')
+        </div>
+    </main>
 
     <!-- Rodapé -->
-    <footer class="site-footer text-center py-4">
+    <footer class="site-footer text-center py-4 mt-auto">
         <p class="footer-copy">Pet Projeto &copy; 2025</p>
 
         <a href="{{ route('politica') }}" class="footer-link">


### PR DESCRIPTION
## Summary
- make the layout use a flex column structure so the footer stays at the bottom
- wrap page content in a padded main area to account for the fixed navbar without disturbing other views

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69248e674fc0833291fa17db64a85f38)