### PR TITLE
Add availability filter toggle to adoption page

### DIFF
--- a/resources/views/adotar.blade.php
+++ b/resources/views/adotar.blade.php
@@ -237,7 +237,11 @@
                     </select>
                 </div>
 
-                <div class="col-6 col-md-3 mt-2 mt-md-0 d-flex align-items-center">
+                <div class="col-6 col-md-3 mt-2 mt-md-0 d-flex align-items-center justify-content-end">
+                    <div class="form-check form-switch">
+                        <input class="form-check-input" type="checkbox" role="switch" id="filtroDisponivel" checked>
+                        <label class="form-check-label" for="filtroDisponivel">Apenas disponíveis</label>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add the "Apenas disponíveis" switch to the adoption filter bar so the availability filter works with the existing script

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934c219a968833283788bc21c1c2e08)