### PR TITLE
Filtrar campanha de pets adultos

### DIFF
--- a/app/Http/Controllers/PetController.php
+++ b/app/Http/Controllers/PetController.php
@@ -8,9 +8,16 @@ use Illuminate\Support\Facades\Auth;
 
 class PetController extends Controller
 {
-    public function adotar()
+    public function adotar(Request $request)
     {
-        $pets = Pet::with('ong')->get();
+        $query = Pet::with('ong');
+
+        if ($request->filled('idade_min')) {
+            $query->where('idade', '>=', (int) $request->idade_min);
+        }
+
+        $pets = $query->get();
+
         return view('adotar', compact('pets')); // sem 'pets.' antes
     }
 

--- a/resources/views/adotar.blade.php
+++ b/resources/views/adotar.blade.php
@@ -247,6 +247,12 @@
         </div>
         {{-- FIM BARRA DE FILTRO --}}
 
+        @if(request('idade_min'))
+            <div class="alert alert-info py-2 px-3 small mb-3">
+                Mostrando pets com {{ request('idade_min') }} anos ou mais.
+            </div>
+        @endif
+
         <h1>Pets disponíveis</h1>
         <div class="row">
             @foreach ($pets as $pet)

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -122,7 +122,7 @@
                             <div class="campaign-text">
                                 Animais adultos esperam há meses por uma chance. Veja os pets dessa campanha e mude uma vida hoje.
                             </div>
-                            <a href="{{ url('/adotar') }}" class="btn btn-light campaign-btn">
+                            <a href="{{ route('adotar', ['idade_min' => 4]) }}" class="btn btn-light campaign-btn">
                                 Ver pets da campanha
                             </a>
                         </div>


### PR DESCRIPTION
## Summary
- direciona o botão da campanha para a listagem já filtrada por idade mínima
- ajusta o controller para aceitar filtro de idade mínima na listagem de adoção
- exibe aviso na tela de adoção quando o filtro por idade é aplicado

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935dc73a8ac8332a6b4079040d24a8d)