### PR TITLE
Otimizando carregamento de estados e cidades no cadastro

### DIFF
--- a/public/js/cidadesEstados.js
+++ b/public/js/cidadesEstados.js
@@ -1,47 +1,63 @@
-document.addEventListener('DOMContentLoaded', function () {
-    console.log("Script cidadesEstados.js carregado");
-
+document.addEventListener('DOMContentLoaded', () => {
     const estadoSelect = document.getElementById('estado');
     const cidadeSelect = document.getElementById('cidade');
 
     if (!estadoSelect || !cidadeSelect) {
-        console.warn("Campos de estado ou cidade não encontrados no DOM.");
+        console.warn('Campos de estado ou cidade não encontrados no DOM.');
         return;
     }
 
-    console.log("Buscando estados...");
+    let estadosCarregados = false;
 
-    fetch('https://servicodados.ibge.gov.br/api/v1/localidades/estados?orderBy=nome')
-        .then(res => res.json())
-        .then(estados => {
-            estados.forEach(estado => {
-                const option = document.createElement('option');
-                option.value = estado.sigla;
-                option.textContent = estado.nome;
-                estadoSelect.appendChild(option);
+    const carregarEstados = () => {
+        if (estadosCarregados) return;
+
+        estadosCarregados = true;
+        estadoSelect.innerHTML = '<option value="">Carregando estados...</option>';
+        estadoSelect.disabled = true;
+
+        fetch('https://servicodados.ibge.gov.br/api/v1/localidades/estados?orderBy=nome')
+            .then((res) => res.json())
+            .then((estados) => {
+                estadoSelect.innerHTML = '<option value="">Selecione um estado</option>';
+
+                estados.forEach((estado) => {
+                    const option = document.createElement('option');
+                    option.value = estado.sigla;
+                    option.textContent = estado.nome;
+                    estadoSelect.appendChild(option);
+                });
+
+                estadoSelect.disabled = false;
+            })
+            .catch((err) => {
+                estadoSelect.innerHTML = '<option value="">Erro ao carregar estados</option>';
+                console.error('Erro ao carregar estados:', err);
             });
-            console.log("Estados carregados com sucesso.");
-        })
-        .catch(err => {
-            console.error("Erro ao carregar estados:", err);
-        });
+    };
+
+    estadoSelect.addEventListener('focus', carregarEstados, { once: true });
+    estadoSelect.addEventListener('click', carregarEstados, { once: true });
+    estadoSelect.addEventListener('touchstart', carregarEstados, { once: true, passive: true });
 
     estadoSelect.addEventListener('change', function () {
         const sigla = this.value;
 
-        if (!sigla) return;
+        if (!sigla) {
+            cidadeSelect.innerHTML = '<option value="">Selecione uma cidade</option>';
+            cidadeSelect.disabled = true;
+            return;
+        }
 
         cidadeSelect.innerHTML = '<option value="">Carregando cidades...</option>';
         cidadeSelect.disabled = true;
 
-        console.log(`Buscando cidades para o estado: ${sigla}`);
-
         fetch(`https://servicodados.ibge.gov.br/api/v1/localidades/estados/${sigla}/municipios`)
-            .then(res => res.json())
-            .then(cidades => {
+            .then((res) => res.json())
+            .then((cidades) => {
                 cidadeSelect.innerHTML = '<option value="">Selecione uma cidade</option>';
 
-                cidades.forEach(cidade => {
+                cidades.forEach((cidade) => {
                     const option = document.createElement('option');
                     option.value = cidade.nome;
                     option.textContent = cidade.nome;
@@ -49,12 +65,11 @@ document.addEventListener('DOMContentLoaded', function () {
                 });
 
                 cidadeSelect.disabled = false;
-                console.log(`Cidades de ${sigla} carregadas com sucesso.`);
             })
-            .catch(err => {
+            .catch((err) => {
                 cidadeSelect.innerHTML = '<option value="">Erro ao carregar cidades</option>';
                 cidadeSelect.disabled = true;
-                console.error("Erro ao carregar cidades:", err);
+                console.error('Erro ao carregar cidades:', err);
             });
     });
 });


### PR DESCRIPTION
## Summary
- adia a requisição dos estados para o primeiro foco/clique do usuário
- mantém feedback visual enquanto estados e cidades são carregados
- desabilita o seletor de cidades quando não há estado selecionado para evitar erros

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935f6b80b608332800e1a8fe569967c)