### PR TITLE
Corrigir sintaxe da descrição do compartilhamento no Facebook

### DIFF
--- a/app/Http/Controllers/OngPainelController.php
+++ b/app/Http/Controllers/OngPainelController.php
@@ -321,13 +321,22 @@ class OngPainelController extends Controller
 
         $linkPet = $this->gerarLinkPet($pet);
 
-        return trim(implode(' ', [
-            "{$pet->nome} ({$especie}) - {$genero}, porte {$porte}, {$idade}.",
+        $caracteristicas = trim(implode(' ', array_filter([
+            "O pet {$pet->nome} é um {$especie}",
+            $genero ? strtolower($genero) : null,
+            $porte ? 'de porte ' . strtolower($porte) : null,
+            $idade ? 'com ' . $idade : null,
+        ])) . '.');
+
+        $detalhes = array_filter([
+            $caracteristicas,
             $descricao,
-            $temperamento,
-            $localizacao,
-            "Adote aqui: {$linkPet}",
-        ]));
+            $temperamento ? 'Ele é um pet ' . str_replace(',', ' e', strtolower($pet->temperamento)) . '.' : null,
+            $localizacao ? 'Está esperando por uma família em ' . $pet->localizacao . '.' : null,
+            'Adote aqui: ' . $linkPet,
+        ]);
+
+        return trim(implode(' ', $detalhes));
     }
 
     private function gerarUrlFotoPet(Pet $pet): ?string


### PR DESCRIPTION
## Summary
- corrigir sintaxe na geração de descrição de compartilhamento do pet para evitar erro de carregamento do painel

## Testing
- php -l app/Http/Controllers/OngPainelController.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936322286748332b89abb7495729376)