### PR TITLE
Add match AI environment guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,12 @@ If you discover a security vulnerability within Laravel, please send an e-mail t
 ## License
 
 The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).
+
+## Configurando a IA de Match
+
+Para que o recurso de sugestão automática de pets funcione em produção (por exemplo, no Railway), configure as seguintes variáveis de ambiente:
+
+- `OPENAI_API_KEY`: chave da API usada pelo `scripts/match.py` para chamar o modelo da OpenAI.
+- `PYTHON_BIN` (opcional): caminho do executável Python disponível no container. Se não definir, será usado `python3`.
+
+No Railway, defina essas variáveis em **Project Settings → Variables**. O Laravel passa esses valores para o script Python sempre que o match é solicitado, portanto não é necessário editar o código ou commitar a chave no repositório.

--- a/app/Http/Controllers/MatchController.php
+++ b/app/Http/Controllers/MatchController.php
@@ -59,8 +59,8 @@ class MatchController extends Controller
                 'pets' => $petsForAI,
             ]);
 
-            // 3. Caminho fixo do Python
-            $pythonPath = 'C:\Users\Surfi\AppData\Local\Programs\Python\Python311\python.exe';
+            // 3. Caminho do Python definido via ambiente (compatível com deploy)
+            $pythonPath = env('PYTHON_BIN', 'python3');
             $pythonScript = base_path('scripts/match.py');
 
             // 4. Executa Python
@@ -69,6 +69,7 @@ class MatchController extends Controller
             $process->setTimeout(30);
             $process->setEnv(array_merge(getenv(), [
                 'PATH' => getenv('PATH'),
+                'OPENAI_API_KEY' => env('OPENAI_API_KEY'),
             ]));
             $process->run();
 

--- a/scripts/match.py
+++ b/scripts/match.py
@@ -1,7 +1,12 @@
-import json, sys, requests
+import json, os, sys, requests
 
-# Chave fixa aqui
-#API_KEY =""
+
+def obter_api_key() -> str:
+    """Recupera a chave da API de uma variável de ambiente segura."""
+    chave = os.getenv("OPENAI_API_KEY")
+    if not chave:
+        raise EnvironmentError("Variável de ambiente OPENAI_API_KEY não definida.")
+    return chave
 
 INSTRUCOES = """
 Você é um especialista em adoção responsável de animais.
@@ -29,11 +34,12 @@ Dados do adotante: {adotante}
 Pets disponíveis: {pets}
 """
     try:
+        api_key = obter_api_key()
         resp = requests.post(
             "https://api.openai.com/v1/chat/completions",
             headers={
                 "Content-Type": "application/json",
-                "Authorization": f"Bearer {API_KEY}"
+                "Authorization": f"Bearer {api_key}"
             },
             json={
                 "model": "gpt-4.1-mini",


### PR DESCRIPTION
## Summary
- document how to configure the match AI environment variables, including OPENAI_API_KEY, for deployments such as Railway

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69363be216fc8332bf15dd5d608f368f)