### PR TITLE
Add partner onboarding view and link from navbar

### DIFF
--- a/resources/views/layouts/main.blade.php
+++ b/resources/views/layouts/main.blade.php
@@ -107,7 +107,7 @@
                         <a class="nav-link btn-menu" id="btn-login" href="{{ route('login') }}">Entrar</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link btn-menu" id="btn-parceiro" href="#">Seja um parceiro</a>
+                        <a class="nav-link btn-menu" id="btn-parceiro" href="{{ route('parceiro') }}">Seja um parceiro</a>
                     </li>
                 @endauth
             </ul>

--- a/resources/views/parceiro.blade.php
+++ b/resources/views/parceiro.blade.php
@@ -1,0 +1,86 @@
+@extends('layouts.main')
+
+@section('title', 'Seja um parceiro')
+
+@section('head')
+<style>
+    .partner-wrapper {
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 3rem 1rem 4rem;
+        font-family: 'Poppins', sans-serif;
+        color: #3d3a40;
+    }
+
+    .partner-card {
+        background: #ffffff;
+        border-radius: 18px;
+        padding: 2.5rem 2rem;
+        box-shadow: 0px 8px 24px rgba(0,0,0,0.08);
+        animation: fadeIn .4s ease-out;
+    }
+
+    @keyframes fadeIn {
+        from { opacity: 0; transform: translateY(10px); }
+        to   { opacity: 1; transform: translateY(0); }
+    }
+
+    .partner-title {
+        font-weight: 700;
+        font-size: 2.2rem;
+        color: #592374ff;
+        margin-bottom: 1rem;
+        text-align: center;
+    }
+
+    .partner-lead {
+        color: #7d7a82;
+        font-size: 1rem;
+        text-align: center;
+        margin-bottom: 2rem;
+    }
+
+    .partner-steps {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: grid;
+        gap: 1rem;
+    }
+
+    .partner-steps li {
+        background: #f7f2fa;
+        border-left: 4px solid #8c5db5;
+        padding: 1rem 1.2rem;
+        border-radius: 10px;
+        line-height: 1.6rem;
+    }
+
+    .partner-email {
+        display: inline-flex;
+        align-items: center;
+        gap: .5rem;
+        font-weight: 600;
+        color: #8c5db5;
+        text-decoration: none;
+    }
+</style>
+@endsection
+
+@section('content')
+<div class="partner-wrapper">
+    <div class="partner-card">
+        <h1 class="partner-title">Torne-se uma ONG parceira</h1>
+        <p class="partner-lead">
+            Quer divulgar seus animais para adoção na plataforma? Envie seus dados e entraremos em contato.
+        </p>
+
+        <ul class="partner-steps">
+            <li>Apresente o nome da ONG e o CNPJ.</li>
+            <li>Inclua as informações de contato do responsável.</li>
+            <li>Compartilhe cidade, estado e links de redes sociais.</li>
+            <li>Envie tudo para o e-mail <a class="partner-email" href="mailto:viniciusdevenezio@gmail.com">viniciusdevenezio@gmail.com</a>.</li>
+        </ul>
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -147,6 +147,9 @@ Route::get('/storage/images/{file}', function (string $file) {
 // Política de privacidade ---------------------------------------
 Route::view('/politica-de-privacidade', 'politica-privacidade')->name('politica');
 
+// Parcerias -----------------------------------------------------
+Route::view('/seja-um-parceiro', 'parceiro')->name('parceiro');
+
 
 Route::get('/teste-make3', function () {
     $url = 'https://hook.us2.make.com/rg9i0wmm0su9dvzwlggirg4p6jn4ye56';


### PR DESCRIPTION
## Summary
- add a dedicated "Seja um parceiro" page with onboarding instructions for ONGs
- register the new page route and connect the navbar partner button to it

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693705bab5388332985a667dec563ec2)