### PR TITLE
[codex] reaplica modernização visual

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1,36 +1,56 @@
-* { 
+:root {
+    --pet-blue: #0887F2;
+    --pet-blue-dark: #0B5ED7;
+    --pet-orange: #ffb01d;
+    --pet-orange-dark: #ff7a3c;
+    --pet-ink: #1f2937;
+    --pet-muted: #667085;
+    --pet-border: rgba(15, 23, 42, 0.1);
+    --pet-surface: rgba(255, 255, 255, 0.94);
+    --pet-shadow: 0 18px 45px rgba(15, 23, 42, 0.12);
+}
+
+* {
     font-family: 'Poppins', sans-serif;
 }
 
 body {
-    background-image: url('/img/backgroundpattern.jpg');
-    background-repeat: repeat; /* Faz o padrão se repetir em todas as direções */
-    background-size: auto; /* Deixa o tamanho original da imagem */
-    background-position: top left; /* Começa a repetição no canto superior esquerdo */
-    font-family: 'Poppins', sans-serif;
+    background:
+        linear-gradient(180deg, rgba(255, 176, 29, 0.08), rgba(8, 135, 242, 0.05) 42%, rgba(255, 255, 255, 0.86)),
+        url('/img/backgroundpattern.jpg');
+    background-repeat: repeat;
+    background-size: auto;
+    background-position: top left;
+    color: var(--pet-ink);
     min-height: 100vh;
     display: flex;
     flex-direction: column;
 }
-    .main-content {
-        padding-top: 0 !important;
-    }
+
+.main-content {
+    padding-top: 88px !important;
+}
+
+.main-content > .container {
+    max-width: 1180px;
+}
 
 .site-footer {
-    background-color: #ffffff;
-    padding: 6px 0;     
-    padding: 6px 0;
+    background-color: rgba(255, 255, 255, 0.9);
+    backdrop-filter: blur(12px);
+    padding: 14px 0;
     text-align: center;
     width: 100%;
     margin-top: auto;
-    box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.05);
-    border-top: 1px solid rgba(0, 0, 0, 0.04);
+    box-shadow: 0 -10px 28px rgba(15, 23, 42, 0.06);
+    border-top: 1px solid var(--pet-border);
     bottom: 0;
     left: 0;
 }
+
 .site-footer .footer-copy {
-    font-size: 0.8rem;  /* menor */
-    color: #555;
+    font-size: 0.82rem;
+    color: var(--pet-muted);
     font-weight: 500;
     margin: 0;
 }
@@ -38,9 +58,9 @@ body {
 .site-footer .footer-link {
     display: inline-block;
     margin-top: 2px;
-    color: #0B5ED7;
+    color: var(--pet-blue-dark);
     text-decoration: none;
-    font-size: 0.75rem; /* menor */
+    font-size: 0.75rem;
     font-weight: 500;
     transition: opacity 0.2s ease;
 }
@@ -48,59 +68,68 @@ body {
 .site-footer .footer-link:hover {
     opacity: 0.7;
 }
+
 #cardsAdotar {
     margin-top: 0 !important;
     padding-top: 1rem !important;
 }
 
-/* Navbar personalizada */
 .custom-navbar {
     position: fixed;
     top: 0;
     left: 0;
     width: 100%;
-    background-color: rgb(255, 255, 255); 
-    box-shadow: 6px 4px 6px rgba(0, 0, 0, 0.1);
-    padding: 0px 25px;
+    background-color: rgba(255, 255, 255, 0.88);
+    border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+    box-shadow: 0 14px 35px rgba(15, 23, 42, 0.08);
+    backdrop-filter: blur(14px);
+    padding: 8px clamp(16px, 4vw, 42px);
     z-index: 1000;
-     display: flex;
-    justify-content: center; /* centraliza os itens */
-    width: 100%;
+    display: flex;
+    justify-content: center;
 }
 
-/* Links padrão do menu */
 .custom-navbar .nav-link {
-    color: #333; /* Cor padrão dos links */
-    font-weight: 500;
-    padding: 0 15px;              /* corrigido (antes estava "px 15px") */
+    color: #2f3a4a;
+    font-size: 0.86rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    padding: 10px 14px !important;
+    border-radius: 10px;
     text-transform: uppercase;
-    transition: color 0.3s ease;
+    transition: color 0.2s ease, background-color 0.2s ease, transform 0.2s ease;
+}
+
+.custom-navbar .nav-link:not(.btn-adotar):not(.match-btn):not(#btn-login):not(#btn-parceiro):hover {
+    color: var(--pet-blue-dark);
+    background-color: rgba(8, 135, 242, 0.08);
+    transform: translateY(-1px);
 }
 
 .logo-navbar {
-    height: 60px; /* Ajuste a altura conforme necessário */
-    width: auto; /* Mantém a proporção da imagem */
+    height: 58px;
+    width: auto;
+    filter: drop-shadow(0 8px 14px rgba(15, 23, 42, 0.12));
 }
 
 .navbar-nav {
     display: flex;
     align-items: center;
-    gap: 5px; /* Aumenta o espaço entre os itens */
+    gap: 7px;
 }
 
 .navbar-brand {
     display: flex;
     align-items: center;
+    margin-right: 1.25rem;
 }
 
-
-/* Botão Match */
 .match-btn {
-    font-weight: 600;
+    font-weight: 700;
     color: #fff !important;
     background: linear-gradient(270deg, #ff8a00, #e52e71, #9b51e0, #2d9cdb);
     background-size: 800% 800%;
-    border-radius: 25px;
+    border-radius: 999px;
     padding: 8px 18px !important;
     margin-right: 10px;
     position: relative;
@@ -113,58 +142,49 @@ body {
     overflow: hidden;
 }
 
-/* Ícone da estrela */
 .match-btn i {
     font-size: 1rem;
     animation: starGlow 2s infinite ease-in-out;
 }
 
-/* Bordas animadas só no hover */
 .match-btn::before {
     content: "";
     position: absolute;
     inset: 0;
-    border-radius: 25px;
+    border-radius: 999px;
     padding: 2px;
-    background: linear-gradient(90deg, 
-        rgba(255,255,255,0.9), 
-        rgba(255,255,255,0.3), 
-        rgba(255,255,255,0.9)
-    );
+    background: linear-gradient(90deg, rgba(255,255,255,0.9), rgba(255,255,255,0.3), rgba(255,255,255,0.9));
     background-size: 300% 300%;
-    -webkit-mask: 
-        linear-gradient(#fff 0 0) content-box, 
-        linear-gradient(#fff 0 0);
+    -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
     -webkit-mask-composite: xor;
     mask-composite: exclude;
     animation: borderWhiteRun 3s linear infinite;
     z-index: -1;
-    opacity: 0; /* invisível por padrão */
+    opacity: 0;
     transition: opacity 0.3s ease;
 }
-.match-btn:hover::before { opacity: 1; }
 
-/* Animação gradiente de fundo */
+.match-btn:hover::before {
+    opacity: 1;
+}
+
 @keyframes gradientMove {
     0% { background-position: 0% 50%; }
     50% { background-position: 100% 50%; }
     100% { background-position: 0% 50%; }
 }
 
-/* Animação da borda branca correndo */
 @keyframes borderWhiteRun {
-    0%   { background-position: 0% 50%; }
+    0% { background-position: 0% 50%; }
     100% { background-position: 300% 50%; }
 }
 
-/* Estrela discreta */
 @keyframes starGlow {
-    0%   { color: #fff; text-shadow: 0 0 3px #fff; }
-    50%  { color: #fff; text-shadow: 0 0 8px rgba(255,255,255,0.6); }
+    0% { color: #fff; text-shadow: 0 0 3px #fff; }
+    50% { color: #fff; text-shadow: 0 0 8px rgba(255,255,255,0.6); }
     100% { color: #fff; text-shadow: 0 0 3px #fff; }
 }
 
-/* Definição da animação antiga (não usada nos botões azuis agora) */
 @keyframes bounce {
     0% { bottom: -100%; }
     50% { bottom: -50%; }
@@ -176,100 +196,95 @@ body {
     100% { bottom: 0; }
 }
 
-/* =========================
-   Botões azuis (login/logout/parceiro)
-   — efeito fluido + contorno visível + canto meio quadrado
-========================= */
 #btn-login,
 #btn-logout,
 #btn-parceiro {
-  background:#fff;
-  color:#0887F2;
-  /* trocamos border por outline p/ o contorno não ser coberto */
-  border: 0;
-  outline: 3px solid #0887F2;   /* contorno sempre visível */
-  border-radius: 4px;
-  padding: 10px 20px;
-  font-weight: 500;
-  text-decoration: none;
-  margin-left: 10px;
-  font-size: 14px;
-  position: relative;
-  overflow: hidden;
-  transition: color .25s ease;
-  z-index: 1;
+    background: #fff;
+    color: var(--pet-blue);
+    border: 0;
+    outline: 2px solid var(--pet-blue);
+    border-radius: 8px;
+    padding: 10px 18px !important;
+    font-weight: 700;
+    text-decoration: none;
+    margin-left: 10px;
+    font-size: 0.85rem;
+    position: relative;
+    overflow: hidden;
+    box-shadow: 0 10px 24px rgba(8, 135, 242, 0.12);
+    transition: color .25s ease, transform .2s ease, box-shadow .2s ease;
+    z-index: 1;
 }
 
-
-/* camada interna de preenchimento (ligeiramente menor p/ deixar a borda aparecer) */
 #btn-login::after,
 #btn-logout::after,
 #btn-parceiro::after {
-  content: '';
-  position: absolute;
-  top: -1px;        /* sobe 1px pra cobrir bordas */
-  left: -1px;       /* estica 1px à esquerda */
-  right: -1px;      /* estica 1px à direita */
-  bottom: -1px;     /* desce 1px pra cobrir o rodapé */
-  background: #0887F2;
-  border-radius: px;      /* ligeiramente maior pra seguir o novo tamanho */
-  transform: translateY(103%);  /* +3% pra compensar o overflow */
-  transition: transform .45s cubic-bezier(.22,.61,.36,1);
-  will-change: transform;
-  z-index: -1;
+    content: '';
+    position: absolute;
+    top: -1px;
+    left: -1px;
+    right: -1px;
+    bottom: -1px;
+    background: var(--pet-blue);
+    border-radius: 8px;
+    transform: translateY(103%);
+    transition: transform .45s cubic-bezier(.22,.61,.36,1);
+    will-change: transform;
+    z-index: -1;
 }
 
-
-/* estados controlados via JS (.is-on / .is-off) */
 #btn-login.is-on,
 #btn-logout.is-on,
-#btn-parceiro.is-on { color: #fff; }    /* texto branco quando cheio */
+#btn-parceiro.is-on {
+    color: #fff;
+}
 
 #btn-login.is-on::after,
 #btn-logout.is-on::after,
-#btn-parceiro.is-on::after { transform: translateY(0%); }
+#btn-parceiro.is-on::after {
+    transform: translateY(0%);
+}
 
 #btn-login.is-off::after,
 #btn-logout.is-off::after,
-#btn-parceiro.is-off::after { transform: translateY(100%); }
+#btn-parceiro.is-off::after {
+    transform: translateY(100%);
+}
 
-/* hover só reforça contraste do texto (opcional) */
 #btn-login:hover,
 #btn-logout:hover,
-#btn-parceiro:hover { color: #fff; }
+#btn-parceiro:hover {
+    color: #fff;
+    box-shadow: 0 14px 30px rgba(8, 135, 242, 0.2);
+    transform: translateY(-1px);
+}
 
-/* Botão Quero Adotar */
 .custom-navbar .btn-adotar {
-    background-color: #ffb01d;
+    background-color: var(--pet-orange);
     color: #fff !important;
-    border: 2px solid #ffb01d;
-    padding: 10px 24px;          /* levemente mais largo p/ oval ficar bonito */
-    border-radius: 25px;         /* deixa oval, igual ao Match */
-    font-weight: 500;
-    margin-left: 10px;  
-    font-size: 14px;
-    transition: all 0.3s ease;
+    border: 2px solid var(--pet-orange);
+    padding: 10px 24px !important;
+    border-radius: 999px;
+    font-weight: 700;
+    margin-left: 10px;
+    font-size: 0.86rem;
+    box-shadow: 0 14px 28px rgba(255, 176, 29, 0.28);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
 }
 
-/* Responsivo */
-@media (max-width: 768px) {
-    .navbar-nav {
-        width: 100%;
-        text-align: center;
-    }
-    .navbar-nav .nav-item {
-        margin-bottom: 10px;
-    }
+.custom-navbar .btn-adotar:hover {
+    background-color: var(--pet-orange-dark);
+    border-color: var(--pet-orange-dark);
+    transform: translateY(-1px);
+    box-shadow: 0 16px 34px rgba(255, 122, 60, 0.28);
 }
 
-/* css do carrossel */
 .carousel-inner .carousel-item img {
-    margin-top: 5%;
-    width: 100%;            /* Imagem ocupa toda a largura do container */
-    height: 550px;          /* Altura fixa */
-    object-fit: cover;      /* Preenche sem distorcer */
+    margin-top: 0;
+    width: 100%;
+    height: 550px;
+    object-fit: cover;
 }
-
 
 .carousel-indicators {
     position: absolute;
@@ -294,12 +309,12 @@ body {
 .carousel-indicators .active {
     background-color: white;
 }
-/* Login */
+
 .login-container {
     max-width: 66vw;
     margin: auto;
     padding: 5vh 5vw;
-    margin-top: -14rem; /* Ajusta a posição para sobrepor o fundo roxo */
+    margin-top: -14rem;
     display: flex;
     gap: 2rem;
     justify-content: center;
@@ -309,20 +324,20 @@ body {
     z-index: 2;
 }
 
-/* esses cards são só do LOGIN */
 .login-container .card {
     flex: 1;
     min-width: 20rem;
     padding: 2rem;
-    border-radius: 0.625rem;
-    box-shadow: 0 0.25rem 0.625rem rgba(0, 0, 0, 0.1);
+    border-radius: 8px;
+    box-shadow: var(--pet-shadow);
     display: flex;
     flex-direction: column;
     justify-content: space-between;
     align-items: center;
     text-align: center;
     height: auto;
-    border:none;
+    border: 1px solid var(--pet-border);
+    background: var(--pet-surface);
 }
 
 .card.p-4 *,
@@ -332,18 +347,12 @@ card.p-4 *::before,
     animation: none !important;
 }
 
-.card:first-child {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    height: 100%; /* Garante altura total */
-}
-
+.card:first-child,
 .card:last-child {
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-    height: 100%; /* Faz os dois cards terem a mesma altura */
+    height: 100%;
 }
 
 .btn-orange {
@@ -352,7 +361,7 @@ card.p-4 *::before,
     border: none;
     padding: 0.75rem 1.5rem;
     font-size: 1rem;
-    border-radius: 0.5rem;
+    border-radius: 8px;
     cursor: pointer;
     transition: background 0.3s, color 0.3s;
     width: 100%;
@@ -364,41 +373,42 @@ card.p-4 *::before,
 }
 
 .btn-outline-primary {
-    border: 0.125rem solid #007bff;
-    color: #007bff;
+    border: 0.125rem solid var(--pet-blue);
+    color: var(--pet-blue);
     padding: 0.75rem 1.5rem;
     font-size: 1rem;
-    border-radius: 0.5rem;
+    border-radius: 8px;
     cursor: pointer;
     transition: background 0.3s, color 0.3s;
     width: 100%;
-    margin-top: auto; /* Empurra o botão para a parte inferior */
+    margin-top: auto;
 }
 
 .btn-outline-primary:hover {
-    background-color: #007bff;
+    background-color: var(--pet-blue);
     color: white;
 }
 
 .btn-adotante {
-    margin-top: auto; /* Empurra o botão para a parte inferior */
+    margin-top: auto;
 }
 
 .form-control {
     width: 100%;
     padding: 0.75rem;
-    border: 0.0625rem solid #ccc;
-    border-radius: 0.5rem;
+    border: 1px solid var(--pet-border);
+    border-radius: 8px;
     box-sizing: border-box;
     font-size: 1rem;
     transition: all 0.3s ease-in-out;
     margin-bottom: 1rem;
+    background-color: #fff;
 }
 
 .form-control:focus {
-    border-color: #74B9FF;
+    border-color: var(--pet-blue);
     outline: none;
-    box-shadow: 0 0 0.3125rem rgba(116, 185, 255, 0.8);
+    box-shadow: 0 0 0 0.22rem rgba(8, 135, 242, 0.14);
 }
 
 .form-check {
@@ -410,8 +420,8 @@ card.p-4 *::before,
 }
 
 .welcome-banner {
-    background-color: #c2b5c5; /* Cor de fundo roxa clara */
-    padding: 7rem 0.25vw; /* Reduz a altura para evitar espaços excessivos */
+    background-color: #c2b5c5;
+    padding: 7rem 0.25vw;
     text-align: center;
     display: flex;
     justify-content: center;
@@ -422,21 +432,20 @@ card.p-4 *::before,
 }
 
 .welcome-banner h1 {
-    font-size: 2.5rem; /* Ajusta o tamanho do texto */
-    color: #523f5f; /* Cor do texto parecida com a da imagem */
-    margin: 0;
-    margin-bottom: 4rem;
+    font-size: 2.5rem;
+    color: #523f5f;
+    margin: 0 0 4rem;
 }
 
-/* CADASTRO DE USUARIO */
 #cadastro-container {
     max-width: 800px;
-    background-color: #f8f8f8;
+    background-color: var(--pet-surface);
     padding: 20px;
-    border-radius: 10px;
-    box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.1);
+    border: 1px solid var(--pet-border);
+    border-radius: 8px;
+    box-shadow: var(--pet-shadow);
     margin: auto;
-    margin-top: 0rem;
+    margin-top: 0;
     min-height: 400px;
 }
 
@@ -458,8 +467,8 @@ form label {
 }
 
 form input.form-control {
-    border: 1px solid #ccc;
-    border-radius: 5px;
+    border: 1px solid var(--pet-border);
+    border-radius: 8px;
     padding: 8px;
     background-color: #fff;
 }
@@ -468,26 +477,61 @@ form input.form-control {
     color: #ff5733;
 }
 
-
 #cadastro-botao .btn-custom {
-    background-color: #ffb01d;
+    background-color: var(--pet-orange);
     color: white;
     font-weight: bold;
     padding: 10px 20px;
-    border-radius: 5px;
+    border-radius: 8px;
     border: none;
 }
 
 .row {
-    margin-bottom: 15px; /* Adiciona um espaçamento entre as linhas */
+    margin-bottom: 15px;
 }
 
-.form-control {
-    width: 100%; /* Garante que os inputs fiquem dentro da largura da coluna */
+#alertaAdocao {
+    margin-top: 1rem;
 }
 
-#alertaAdocao{
-    margin-top:6rem;
+@media (max-width: 768px) {
+    .main-content {
+        padding-top: 82px !important;
+    }
+
+    .custom-navbar {
+        padding: 8px 16px;
+    }
+
+    .navbar-collapse {
+        background: rgba(255, 255, 255, 0.96);
+        border: 1px solid var(--pet-border);
+        border-radius: 14px;
+        box-shadow: var(--pet-shadow);
+        margin-top: 10px;
+        padding: 12px;
+    }
+
+    .navbar-nav {
+        width: 100%;
+        text-align: center;
+    }
+
+    .navbar-nav .nav-item {
+        margin-bottom: 10px;
+    }
+
+    #btn-login,
+    #btn-logout,
+    #btn-parceiro,
+    .custom-navbar .btn-adotar {
+        margin-left: 0;
+        width: 100%;
+    }
+
+    .login-container {
+        max-width: 100%;
+        padding: 2rem 1rem;
+        margin-top: -8rem;
+    }
 }
-
-

--- a/resources/views/adotar.blade.php
+++ b/resources/views/adotar.blade.php
@@ -11,12 +11,17 @@
             height: 500px;
             display: flex;
             flex-direction: column;
-            border-radius: 14px;
+            border-radius: 8px;
             overflow: hidden;
             background: #fff;
-            box-shadow: 0 10px 25px rgba(0, 0, 0, 0.22);
+            border: 1px solid rgba(15, 23, 42, .08);
+            box-shadow: 0 14px 32px rgba(15, 23, 42, .1);
             transition: transform .2s ease, box-shadow .2s ease;
-            border: none;
+        }
+
+        .pet-card:hover {
+            transform: translateY(-4px);
+            box-shadow: 0 20px 44px rgba(15, 23, 42, .14);
         }
 
         .pet-card .card-img-top {
@@ -124,11 +129,12 @@
         {{-- NOVO: estilo da barra de filtros horizontal --}}
         .filter-bar {
             background: #ffffff;
-            border-radius: 14px;
-            box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+            border-radius: 8px;
+            border: 1px solid rgba(15, 23, 42, .08);
+            box-shadow: 0 14px 32px rgba(15, 23, 42, 0.08);
             margin-bottom: 1.25rem;
-            margin-top:-3rem;
-            padding-bottom: 1px;
+            margin-top: 0;
+            padding: 1rem;
         }
 
         .filter-bar label {

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -5,7 +5,7 @@
         /* ===== SEÇÃO DO CARROSSEL ===== */
 
         .home-section {
-            padding: 1.5rem 0 2.5rem;
+            padding: .5rem 0 2.25rem;
         }
 
         .carousel-control-prev {
@@ -20,16 +20,16 @@
 
         .campaign-carousel .carousel-item img {
             width: 100%;
-            height: 420px;
-         
+            height: clamp(360px, 52vw, 520px);
             object-fit: cover;
-            border-radius: 18px;
+            border-radius: 8px;
         }
 
         .campaign-carousel .carousel-inner {
-            border-radius: 18px;
+            border-radius: 8px;
             overflow: hidden;
-            box-shadow: 0 18px 45px rgba(0, 0, 0, .12);
+            box-shadow: 0 24px 60px rgba(15, 23, 42, .18);
+            border: 1px solid rgba(255, 255, 255, .65);
         }
 
         .campaign-carousel .carousel-caption {
@@ -37,8 +37,8 @@
             right: 0;
             bottom: 0;
             text-align: left;
-            padding: 1.5rem 2rem 1.8rem;
-            background: linear-gradient(to top, rgba(0, 0, 0, .75), rgba(0, 0, 0, .0));
+            padding: 2rem clamp(1.25rem, 4vw, 3rem) 2.25rem;
+            background: linear-gradient(to top, rgba(15, 23, 42, .82), rgba(15, 23, 42, .32), rgba(15, 23, 42, .04));
         }
 
         .campaign-badge {
@@ -46,35 +46,41 @@
             align-items: center;
             gap: .4rem;
             font-size: .8rem;
-            padding: .25rem .8rem;
+            padding: .35rem .85rem;
             border-radius: 999px;
-            background-color: rgba(255, 255, 255, .12);
-            margin-bottom: .6rem;
+            background-color: rgba(255, 255, 255, .18);
+            border: 1px solid rgba(255, 255, 255, .22);
+            backdrop-filter: blur(8px);
+            margin-bottom: .75rem;
         }
 
         .campaign-badge span {
             font-size: .75rem;
             text-transform: uppercase;
-            letter-spacing: .06em;
+            letter-spacing: .08em;
         }
 
         .campaign-title {
-            font-size: 1.2rem;
-            font-weight: 600;
-            margin-bottom: .25rem;
+            font-size: clamp(1.35rem, 3vw, 2.35rem);
+            font-weight: 700;
+            margin-bottom: .4rem;
+            max-width: 680px;
         }
 
         .campaign-text {
-            font-size: .9rem;
-            margin-bottom: .8rem;
-            max-width: 460px;
+            font-size: .98rem;
+            margin-bottom: 1rem;
+            max-width: 560px;
+            color: rgba(255, 255, 255, .9);
         }
 
         .campaign-btn {
             border-radius: 999px;
-            padding: .4rem 1.3rem;
-            font-size: .85rem;
-            font-weight: 500;
+            padding: .55rem 1.35rem;
+            font-size: .88rem;
+            font-weight: 700;
+            color: #0B5ED7;
+            box-shadow: 0 12px 25px rgba(255, 255, 255, .2);
         }
 
         @media (max-width: 768px) {
@@ -89,7 +95,20 @@
 
 
         .home-stats {
-            padding: 1.5rem 0 3rem;
+            padding: .5rem 0 3.25rem;
+        }
+
+        .home-stats .row {
+            background: rgba(255, 255, 255, .9);
+            border: 1px solid rgba(15, 23, 42, .08);
+            border-radius: 8px;
+            box-shadow: 0 18px 45px rgba(15, 23, 42, .1);
+            margin: 0;
+            padding: 1.1rem .5rem;
+        }
+
+        .stat-item {
+            padding: .75rem;
         }
 
         .stat-item h3 {
@@ -101,7 +120,7 @@
         .stat-item p {
             margin: 0;
             font-size: .9rem;
-            color: #6c757d;
+            color: #667085;
         }
 
         .carousel-control-prev,
@@ -112,7 +131,7 @@
             transform: translateY(-50%);
             border-radius: 50%;
             backdrop-filter: blur(6px);
-            background: rgba(255, 255, 255, .15);
+            background: rgba(255, 255, 255, .22);
             transition: all .25s ease;
         }
 

--- a/resources/views/pets/adotarCachorro.blade.php
+++ b/resources/views/pets/adotarCachorro.blade.php
@@ -11,12 +11,17 @@
             height: 500px;
             display: flex;
             flex-direction: column;
-            border-radius: 14px;
+            border-radius: 8px;
             overflow: hidden;
             background: #fff;
-            box-shadow: 0 10px 25px rgba(0, 0, 0, 0.22);
+            border: 1px solid rgba(15, 23, 42, .08);
+            box-shadow: 0 14px 32px rgba(15, 23, 42, .1);
             transition: transform .2s ease, box-shadow .2s ease;
-            border: none;
+        }
+
+        .pet-card:hover {
+            transform: translateY(-4px);
+            box-shadow: 0 20px 44px rgba(15, 23, 42, .14);
         }
 
         .pet-card .card-img-top {
@@ -124,11 +129,12 @@
         {{-- NOVO: estilo da barra de filtros horizontal --}}
         .filter-bar {
             background: #ffffff;
-            border-radius: 14px;
-            box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+            border-radius: 8px;
+            border: 1px solid rgba(15, 23, 42, .08);
+            box-shadow: 0 14px 32px rgba(15, 23, 42, 0.08);
             margin-bottom: 1.25rem;
-            margin-top:-3rem;
-            padding-bottom: 1px;
+            margin-top: 0;
+            padding: 1rem;
         }
 
         .filter-bar label {

--- a/resources/views/pets/adotarGato.blade.php
+++ b/resources/views/pets/adotarGato.blade.php
@@ -11,12 +11,17 @@
             height: 500px;
             display: flex;
             flex-direction: column;
-            border-radius: 14px;
+            border-radius: 8px;
             overflow: hidden;
             background: #fff;
-            box-shadow: 0 10px 25px rgba(0, 0, 0, 0.22);
+            border: 1px solid rgba(15, 23, 42, .08);
+            box-shadow: 0 14px 32px rgba(15, 23, 42, .1);
             transition: transform .2s ease, box-shadow .2s ease;
-            border: none;
+        }
+
+        .pet-card:hover {
+            transform: translateY(-4px);
+            box-shadow: 0 20px 44px rgba(15, 23, 42, .14);
         }
 
         .pet-card .card-img-top {
@@ -124,11 +129,12 @@
         {{-- NOVO: estilo da barra de filtros horizontal --}}
         .filter-bar {
             background: #ffffff;
-            border-radius: 14px;
-            box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+            border-radius: 8px;
+            border: 1px solid rgba(15, 23, 42, .08);
+            box-shadow: 0 14px 32px rgba(15, 23, 42, 0.08);
             margin-bottom: 1.25rem;
-            margin-top:-3rem;
-            padding-bottom: 1px;
+            margin-top: 0;
+            padding: 1rem;
         }
 
         .filter-bar label {


### PR DESCRIPTION
## O que mudou

- Reaplica a modernização visual após o revert do PR #57.
- Atualiza o CSS global mantendo a identidade azul/laranja.
- Mantém o efeito reativo dos botões `Entrar` e `Seja um parceiro`.
- Refina navbar, botão `Quero Adotar`, home, carrossel, estatísticas, filtros e cards de pets.
- Reposiciona a barra de filtros da aba `Adotar` para ficar mais colada ao menu, preservando a estética nova.

## Por que

O design foi revertido anteriormente para destravar o deploy. Agora que o Railway foi corrigido, este PR reaplica as mudanças visuais sobre o `Deploy` atual e mantém a barra de filtros no comportamento visual que você preferia.

## Como voltar depois

Se precisar desfazer depois do merge, reverta este PR pelo GitHub.

## Validação

- `php artisan route:list`