### PR TITLE
[codex] alinha filtros de adoção ao menu

### DIFF
--- a/resources/views/adotar.blade.php
+++ b/resources/views/adotar.blade.php
@@ -133,8 +133,10 @@
             border: 1px solid rgba(15, 23, 42, .08);
             box-shadow: 0 14px 32px rgba(15, 23, 42, 0.08);
             margin-bottom: 1.25rem;
-            margin-top: 0;
+            margin-top: -2.75rem;
             padding: 1rem;
+            position: relative;
+            z-index: 2;
         }
 
         .filter-bar label {
@@ -156,6 +158,12 @@
         .filter-bar .form-check-label {
             font-size: 0.85rem;
             font-weight: 500;
+        }
+
+        @media (max-width: 768px) {
+            .filter-bar {
+                margin-top: -1.5rem;
+            }
         }
     </style>
 @endsection

--- a/resources/views/pets/adotarCachorro.blade.php
+++ b/resources/views/pets/adotarCachorro.blade.php
@@ -133,8 +133,10 @@
             border: 1px solid rgba(15, 23, 42, .08);
             box-shadow: 0 14px 32px rgba(15, 23, 42, 0.08);
             margin-bottom: 1.25rem;
-            margin-top: 0;
+            margin-top: -2.75rem;
             padding: 1rem;
+            position: relative;
+            z-index: 2;
         }
 
         .filter-bar label {
@@ -156,6 +158,12 @@
         .filter-bar .form-check-label {
             font-size: 0.85rem;
             font-weight: 500;
+        }
+
+        @media (max-width: 768px) {
+            .filter-bar {
+                margin-top: -1.5rem;
+            }
         }
     </style>
 @endsection

--- a/resources/views/pets/adotarGato.blade.php
+++ b/resources/views/pets/adotarGato.blade.php
@@ -133,8 +133,10 @@
             border: 1px solid rgba(15, 23, 42, .08);
             box-shadow: 0 14px 32px rgba(15, 23, 42, 0.08);
             margin-bottom: 1.25rem;
-            margin-top: 0;
+            margin-top: -2.75rem;
             padding: 1rem;
+            position: relative;
+            z-index: 2;
         }
 
         .filter-bar label {
@@ -156,6 +158,12 @@
         .filter-bar .form-check-label {
             font-size: 0.85rem;
             font-weight: 500;
+        }
+
+        @media (max-width: 768px) {
+            .filter-bar {
+                margin-top: -1.5rem;
+            }
         }
     </style>
 @endsection


### PR DESCRIPTION
## O que mudou

- Ajusta a barra de filtros nas páginas `Adotar`, `Cachorros` e `Gatos`.
- Mantém a estética nova do card de filtros.
- Reaproxima a barra do menu, como era antes da modernização.
- Usa ajuste responsivo menor em telas mobile.

## Validação

- `php artisan route:list`