### PR TITLE
[codex] Tighten CSP script policy with nonces

### DIFF
--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -10,6 +10,10 @@ class SecurityHeaders
 {
     public function handle(Request $request, Closure $next): Response
     {
+        $nonce = bin2hex(random_bytes(16));
+        $request->attributes->set('csp_nonce', $nonce);
+        view()->share('cspNonce', $nonce);
+
         /** @var Response $response */
         $response = $next($request);
 
@@ -20,9 +24,9 @@ class SecurityHeaders
             "frame-ancestors 'none'",
             "form-action 'self'",
             "img-src 'self' data: https:",
-            "font-src 'self' data:",
+            "font-src 'self'",
             "style-src 'self' 'unsafe-inline'",
-            "script-src 'self' 'unsafe-inline'",
+            "script-src 'self' 'nonce-{$nonce}'",
             "connect-src 'self' https://viacep.com.br https://servicodados.ibge.gov.br",
         ];
 

--- a/resources/views/adotar.blade.php
+++ b/resources/views/adotar.blade.php
@@ -372,7 +372,7 @@
     </div>
 
     {{-- script do filtro horizontal, agora com idade --}}
-    <script>
+    <script nonce="{{ $cspNonce ?? '' }}">
         document.addEventListener('DOMContentLoaded', () => {
             const filtroPorte      = document.getElementById('filtroPorte');
             const filtroGenero     = document.getElementById('filtroGenero');

--- a/resources/views/cadastro.blade.php
+++ b/resources/views/cadastro.blade.php
@@ -264,7 +264,7 @@
 <script src="{{ asset('js/cidadesEstados.js') }}"></script>
 <script src="{{ asset('js/cepAutoComplete.js') }}"></script>
 
-<script>
+<script nonce="{{ $cspNonce ?? '' }}">
     $(function () {
         $('#nascimento').mask('00/00/0000');
         $('#celular').mask('(00) 00000-0000');

--- a/resources/views/cadastroOng.blade.php
+++ b/resources/views/cadastroOng.blade.php
@@ -265,7 +265,7 @@
 <script src="{{ asset('js/cidadesEstados.js') }}"></script>
 <script src="{{ asset('js/cepAutoComplete.js') }}"></script>
 
-<script>
+<script nonce="{{ $cspNonce ?? '' }}">
     $(function () {
         $('#telefone').mask('(00) 00000-0000');
         $('#cep').mask('00000-000');

--- a/resources/views/layouts/main.blade.php
+++ b/resources/views/layouts/main.blade.php
@@ -126,7 +126,7 @@
     <script src="{{ asset('vendor/bootstrap/js/bootstrap.bundle.min.js') }}" defer></script>
 
 </body>
-<script defer>
+<script nonce="{{ $cspNonce ?? '' }}" defer>
     document.addEventListener('DOMContentLoaded', () => {
         const buttons = document.querySelectorAll('#btn-login, #btn-logout, #btn-parceiro');
 

--- a/resources/views/layouts/sidebarpainelong.blade.php
+++ b/resources/views/layouts/sidebarpainelong.blade.php
@@ -220,7 +220,7 @@
   <script src="{{ asset('vendor/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
 
   @auth('ong')
-    <script>
+    <script nonce="{{ $cspNonce ?? '' }}">
       (function () {
         const btn = document.getElementById('btn-toggle-sidebar');
         const sidebar = document.getElementById('sidebar-lateral-ong');

--- a/resources/views/match.blade.php
+++ b/resources/views/match.blade.php
@@ -700,7 +700,7 @@
         --}}
     </div>
 
-    <script>
+    <script nonce="{{ $cspNonce ?? '' }}">
         document.addEventListener('DOMContentLoaded', function () {
             const steps = Array.from(document.querySelectorAll('.match-step'));
             const totalSteps = steps.length;

--- a/resources/views/painel/ong/cadastrarPet.blade.php
+++ b/resources/views/painel/ong/cadastrarPet.blade.php
@@ -252,7 +252,7 @@
             </a>
         </div>
 
-        <script>
+        <script nonce="{{ $cspNonce ?? '' }}">
             // Atualiza a string "idade" (compatibilidade)
             function atualizarIdadeStr() {
                 const n = document.getElementById('idade_num').value;

--- a/resources/views/painel/ong/editarPet.blade.php
+++ b/resources/views/painel/ong/editarPet.blade.php
@@ -314,7 +314,7 @@
 
 
 
-<script>
+<script nonce="{{ $cspNonce ?? '' }}">
     // Atualiza a string "idade" (compatibilidade com o controller)
     function atualizarIdadeStr() {
         const n = document.getElementById('idade_num').value;

--- a/resources/views/painel/ong/pets.blade.php
+++ b/resources/views/painel/ong/pets.blade.php
@@ -65,7 +65,7 @@
                             <td>{{ ucfirst($pet->porte) }}</td>
                             <td>
                                 <form action="{{ route('ong.pets.atualizar.status', $pet->id) }}" method="POST"
-                                    onsubmit="return confirm('Tem certeza que deseja alterar o status do pet?')"
+                                    data-confirm="Tem certeza que deseja alterar o status do pet?"
                                     class="d-flex justify-content-center align-items-center gap-2">
                                     @csrf
                                     @method('PUT')
@@ -91,7 +91,7 @@
                                     @csrf
                                     @method('DELETE')
                                     <button class="btn btn-sm btn-outline-danger"
-                                        onclick="return confirm('Deseja mesmo excluir este pet?')" title="Excluir">
+                                        data-confirm="Deseja mesmo excluir este pet?" title="Excluir">
                                         <i class="bi bi-trash3 fs-5"></i>
                                     </button>
                                 </form>
@@ -110,3 +110,21 @@
         </div>
     @endif
 </div>
+
+<script nonce="{{ $cspNonce ?? '' }}">
+    document.querySelectorAll('form[data-confirm]').forEach((form) => {
+        form.addEventListener('submit', (event) => {
+            if (!confirm(form.dataset.confirm)) {
+                event.preventDefault();
+            }
+        });
+    });
+
+    document.querySelectorAll('button[data-confirm]').forEach((button) => {
+        button.addEventListener('click', (event) => {
+            if (!confirm(button.dataset.confirm)) {
+                event.preventDefault();
+            }
+        });
+    });
+</script>

--- a/resources/views/painel/ong/solicitacoes.blade.php
+++ b/resources/views/painel/ong/solicitacoes.blade.php
@@ -33,10 +33,10 @@
       <h2><i class="bi bi-clipboard-heart text-success me-2"></i> Solicitações de Adoção</h2>
       <div class="filters">
         <div class="btn-group" role="group" aria-label="Filtro status">
-          <button type="button" class="btn btn-outline-secondary btn-sm" data-status="todos" onclick="filtrarStatus('todos')">Todos</button>
-          <button type="button" class="btn btn-outline-warning  btn-sm" data-status="novo" onclick="filtrarStatus('novo')">Novos</button>
-          <button type="button" class="btn btn-outline-success  btn-sm" data-status="aprovado" onclick="filtrarStatus('aprovado')">Aprovados</button>
-          <button type="button" class="btn btn-outline-danger   btn-sm" data-status="recusado" onclick="filtrarStatus('recusado')">Recusados</button>
+          <button type="button" class="btn btn-outline-secondary btn-sm" data-status="todos" data-filter-status="todos">Todos</button>
+          <button type="button" class="btn btn-outline-warning  btn-sm" data-status="novo" data-filter-status="novo">Novos</button>
+          <button type="button" class="btn btn-outline-success  btn-sm" data-status="aprovado" data-filter-status="aprovado">Aprovados</button>
+          <button type="button" class="btn btn-outline-danger   btn-sm" data-status="recusado" data-filter-status="recusado">Recusados</button>
         </div>
       </div>
     </div>
@@ -45,7 +45,7 @@
       <table class="table table-sm table-hover align-middle sol-table mb-0" id="tabelaSolicitacoes">
         <thead class="table-dark">
           <tr>
-            <th class="table-check"><input class="form-check-input" type="checkbox" id="checkAll" onclick="toggleAll(this)"></th>
+            <th class="table-check"><input class="form-check-input" type="checkbox" id="checkAll"></th>
             <th>Pet</th>
             <th>Adotante</th>
             <th>Telefone</th>
@@ -98,8 +98,7 @@
                   <form action="{{ url("/painel/ong/solicitacoes/{$s->id}/aceitar") }}" method="POST" style="display:inline">
                     @csrf
                     <button type="submit" class="btn btn-success px-2 py-1"
-                            data-id="{{ $s->id }}"
-                            onclick="return confirm('Confirmar aprovação desta solicitação?')">
+                            data-id="{{ $s->id }}" data-confirm="Confirmar esta a��o?">
                       <i class="bi bi-check2-circle"></i>
                     </button>
                   </form>
@@ -125,7 +124,7 @@
                     @csrf
                     @method('PATCH')
                     <input type="hidden" name="status" value="recusado">
-                    <button type="submit" class="btn btn-outline-danger px-2 py-1" data-id="{{ $s->id }}" onclick="return confirm('Confirmar recusa desta solicitação?')">
+                    <button type="submit" class="btn btn-outline-danger px-2 py-1" data-id="{{ $s->id }}" data-confirm="Confirmar esta a��o?">
                       <i class="bi bi-x-circle-fill"></i>
                     </button>
                   </form>
@@ -139,7 +138,7 @@
                     <li>
                       <form action="{{ url("/painel/ong/solicitacoes/{$s->id}/aceitar") }}" method="POST" style="display:inline">
                         @csrf
-                        <button type="submit" class="dropdown-item" onclick="return confirm('Confirmar aprovação desta solicitação?')">
+                        <button type="submit" class="dropdown-item" data-confirm="Confirmar esta a��o?">
                           <i class="bi bi-check2-circle me-2"></i> Aceitar
                         </button>
                       </form>
@@ -168,7 +167,7 @@
                         @csrf
                         @method('PATCH')
                         <input type="hidden" name="status" value="recusado">
-                        <button type="submit" class="dropdown-item text-danger" data-id="{{ $s->id }}" onclick="return confirm('Confirmar recusa desta solicitação?')">
+                        <button type="submit" class="dropdown-item text-danger" data-id="{{ $s->id }}" data-confirm="Confirmar esta a��o?">
                           <i class="bi bi-x-circle-fill me-2"></i> Recusar
                         </button>
                       </form>
@@ -183,10 +182,10 @@
     </div>
 
     <div class="d-flex gap-2 mt-3 flex-wrap">
-      <button type="button" class="btn btn-success btn-sm px-2 py-1" onclick="aceitarSelecionados()">
+      <button type="button" class="btn btn-success btn-sm px-2 py-1" id="aceitarSelecionados">
         <i class="bi bi-check2-square me-1"></i> Aceitar Selecionados
       </button>
-      <button type="button" class="btn btn-outline-danger btn-sm px-2 py-1" onclick="recusarSelecionados()">
+      <button type="button" class="btn btn-outline-danger btn-sm px-2 py-1" id="recusarSelecionados">
         <i class="bi bi-x-square me-1"></i> Recusar Selecionados
       </button>
     </div>
@@ -220,7 +219,7 @@
   </div>
 
   {{-- ===== JS (inline — ajustado para manter suas funções e sem interferir nos novos forms) ===== --}}
-  <script>
+  <script nonce="{{ $cspNonce ?? '' }}">
     const CSRF = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content');
 
     function filtrarStatus(status){
@@ -331,5 +330,20 @@
     window.marcarRecusado     = (btn)=>{ const id=btn.dataset.id; if(!id)return; if(confirm('Confirmar recusa desta solicitação?')) atualizarStatus(id,'recusado'); }
     window.aceitarSelecionados= ()=>{ const ids=getSelecionados(); if(!ids.length) return alert('Nenhuma linha selecionada.'); if(confirm(`Aprovar ${ids.length} solicitação(ões)?`)){ ids.forEach(id=>atualizarStatus(id,'aprovado')); document.getElementById('checkAll').checked=false; toggleAll({checked:false}); } }
     window.recusarSelecionados= ()=>{ const ids=getSelecionados(); if(!ids.length) return alert('Nenhuma linha selecionada.'); if(confirm(`Recusar ${ids.length} solicitação(ões)?`)){ ids.forEach(id=>atualizarStatus(id,'recusado')); document.getElementById('checkAll').checked=false; toggleAll({checked:false}); } }
+    document.querySelectorAll('[data-filter-status]').forEach((button) => {
+      button.addEventListener('click', () => filtrarStatus(button.dataset.filterStatus));
+    });
+
+    document.getElementById('checkAll')?.addEventListener('change', (event) => toggleAll(event.target));
+    document.getElementById('aceitarSelecionados')?.addEventListener('click', window.aceitarSelecionados);
+    document.getElementById('recusarSelecionados')?.addEventListener('click', window.recusarSelecionados);
+
+    document.querySelectorAll('[data-confirm]').forEach((button) => {
+      button.addEventListener('click', (event) => {
+        if (!confirm(button.dataset.confirm)) {
+          event.preventDefault();
+        }
+      });
+    });
   </script>
 @endsection

--- a/resources/views/painelOng.blade.php
+++ b/resources/views/painelOng.blade.php
@@ -1,5 +1,5 @@
 @extends('layouts.sidebarpainelong')
-<script>
+<script nonce="{{ $cspNonce ?? '' }}">
     (function () {
         const nav = document.querySelector('.navbar');
         const setNavH = () => {

--- a/resources/views/pets/adotarCachorro.blade.php
+++ b/resources/views/pets/adotarCachorro.blade.php
@@ -367,7 +367,7 @@
     </div>
 
     {{-- script do filtro horizontal, agora com idade --}}
-    <script>
+    <script nonce="{{ $cspNonce ?? '' }}">
         document.addEventListener('DOMContentLoaded', () => {
             const filtroPorte      = document.getElementById('filtroPorte');
             const filtroGenero     = document.getElementById('filtroGenero');

--- a/resources/views/pets/adotarGato.blade.php
+++ b/resources/views/pets/adotarGato.blade.php
@@ -367,7 +367,7 @@
     </div>
 
     {{-- script do filtro horizontal, agora com idade --}}
-    <script>
+    <script nonce="{{ $cspNonce ?? '' }}">
         document.addEventListener('DOMContentLoaded', () => {
             const filtroPorte      = document.getElementById('filtroPorte');
             const filtroGenero     = document.getElementById('filtroGenero');

--- a/resources/views/pets/mostrar.blade.php
+++ b/resources/views/pets/mostrar.blade.php
@@ -221,7 +221,7 @@
             </div>
         </div>
 
-        <script>
+        <script nonce="{{ $cspNonce ?? '' }}">
             document.addEventListener('DOMContentLoaded', function () {
                 var botaoConfirmar = document.getElementById('confirmarEnvioSolicitacao');
                 var formularioSolicitacao = document.getElementById('formSolicitacaoAdocao');
@@ -250,7 +250,7 @@
       </div>
     </div>
   </div>
-  <script>
+  <script nonce="{{ $cspNonce ?? '' }}">
     document.addEventListener('DOMContentLoaded', function () {
       var el = document.getElementById('toastSolic');
       if (el && window.bootstrap && bootstrap.Toast) {


### PR DESCRIPTION
## Summary
- Replaces `script-src 'unsafe-inline'` with a per-request CSP nonce: `script-src 'self' 'nonce-...'`.
- Shares the nonce with Blade views as `$cspNonce` and adds it to inline `<script>` blocks.
- Moves inline HTML event handlers (`onclick`/`onsubmit`) into nonce-authorized scripts.
- Removes `data:` from `font-src`; fonts are served locally.

## Why
HostedScan/Mozilla Observatory reported CSP as implemented unsafely because `script-src` allowed unsafe inline execution. This keeps existing inline scripts working through nonces while removing unsafe inline script execution from the policy.

## Validation
- `php -l app/Http/Middleware/SecurityHeaders.php` passed.
- `php artisan route:list --except-vendor` passed.
- `npm run build` passed.
- `rg --pcre2 "<script(?![^>]*src=)(?![^>]*nonce=)|\\son[a-z]+=" resources/views -n` returns no matches.
- Local `curl -I http://127.0.0.1:8018/login` confirmed CSP emits `script-src 'self' 'nonce-...'` without `unsafe-inline`.

## Note
`style-src` still allows `'unsafe-inline'` because current Blade templates contain inline `<style>` blocks and style attributes. That is separate from the unsafe `script-src` finding and should be removed in a dedicated CSS extraction pass to avoid breaking layout.