### PR TITLE
[codex] Restore previous navbar styling

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -79,57 +79,44 @@ body {
     top: 0;
     left: 0;
     width: 100%;
-    background-color: rgba(255, 255, 255, 0.88);
-    border-bottom: 1px solid rgba(15, 23, 42, 0.08);
-    box-shadow: 0 14px 35px rgba(15, 23, 42, 0.08);
-    backdrop-filter: blur(14px);
-    padding: 8px clamp(16px, 4vw, 42px);
+    background-color: rgb(255, 255, 255);
+    box-shadow: 6px 4px 6px rgba(0, 0, 0, 0.1);
+    padding: 0px 25px;
     z-index: 1000;
     display: flex;
     justify-content: center;
 }
 
 .custom-navbar .nav-link {
-    color: #2f3a4a;
-    font-size: 0.86rem;
-    font-weight: 600;
-    letter-spacing: 0.02em;
-    padding: 10px 14px !important;
-    border-radius: 10px;
+    color: #333;
+    font-weight: 500;
+    padding: 0 15px;
     text-transform: uppercase;
-    transition: color 0.2s ease, background-color 0.2s ease, transform 0.2s ease;
-}
-
-.custom-navbar .nav-link:not(.btn-adotar):not(.match-btn):not(#btn-login):not(#btn-parceiro):hover {
-    color: var(--pet-blue-dark);
-    background-color: rgba(8, 135, 242, 0.08);
-    transform: translateY(-1px);
+    transition: color 0.3s ease;
 }
 
 .logo-navbar {
-    height: 58px;
+    height: 60px;
     width: auto;
-    filter: drop-shadow(0 8px 14px rgba(15, 23, 42, 0.12));
 }
 
 .navbar-nav {
     display: flex;
     align-items: center;
-    gap: 7px;
+    gap: 5px;
 }
 
 .navbar-brand {
     display: flex;
     align-items: center;
-    margin-right: 1.25rem;
 }
 
 .match-btn {
-    font-weight: 700;
+    font-weight: 600;
     color: #fff !important;
     background: linear-gradient(270deg, #ff8a00, #e52e71, #9b51e0, #2d9cdb);
     background-size: 800% 800%;
-    border-radius: 999px;
+    border-radius: 25px;
     padding: 8px 18px !important;
     margin-right: 10px;
     position: relative;
@@ -151,7 +138,7 @@ body {
     content: "";
     position: absolute;
     inset: 0;
-    border-radius: 999px;
+    border-radius: 25px;
     padding: 2px;
     background: linear-gradient(90deg, rgba(255,255,255,0.9), rgba(255,255,255,0.3), rgba(255,255,255,0.9));
     background-size: 300% 300%;
@@ -200,19 +187,18 @@ body {
 #btn-logout,
 #btn-parceiro {
     background: #fff;
-    color: var(--pet-blue);
+    color: #0887F2;
     border: 0;
-    outline: 2px solid var(--pet-blue);
-    border-radius: 8px;
-    padding: 10px 18px !important;
-    font-weight: 700;
+    outline: 3px solid #0887F2;
+    border-radius: 4px;
+    padding: 10px 20px;
+    font-weight: 500;
     text-decoration: none;
     margin-left: 10px;
-    font-size: 0.85rem;
+    font-size: 14px;
     position: relative;
     overflow: hidden;
-    box-shadow: 0 10px 24px rgba(8, 135, 242, 0.12);
-    transition: color .25s ease, transform .2s ease, box-shadow .2s ease;
+    transition: color .25s ease;
     z-index: 1;
 }
 
@@ -225,8 +211,8 @@ body {
     left: -1px;
     right: -1px;
     bottom: -1px;
-    background: var(--pet-blue);
-    border-radius: 8px;
+    background: #0887F2;
+    border-radius: 4px;
     transform: translateY(103%);
     transition: transform .45s cubic-bezier(.22,.61,.36,1);
     will-change: transform;
@@ -255,28 +241,18 @@ body {
 #btn-logout:hover,
 #btn-parceiro:hover {
     color: #fff;
-    box-shadow: 0 14px 30px rgba(8, 135, 242, 0.2);
-    transform: translateY(-1px);
 }
 
 .custom-navbar .btn-adotar {
-    background-color: var(--pet-orange);
+    background-color: #ffb01d;
     color: #fff !important;
-    border: 2px solid var(--pet-orange);
-    padding: 10px 24px !important;
-    border-radius: 999px;
-    font-weight: 700;
+    border: 2px solid #ffb01d;
+    padding: 10px 24px;
+    border-radius: 25px;
+    font-weight: 500;
     margin-left: 10px;
-    font-size: 0.86rem;
-    box-shadow: 0 14px 28px rgba(255, 176, 29, 0.28);
-    transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
-}
-
-.custom-navbar .btn-adotar:hover {
-    background-color: var(--pet-orange-dark);
-    border-color: var(--pet-orange-dark);
-    transform: translateY(-1px);
-    box-shadow: 0 16px 34px rgba(255, 122, 60, 0.28);
+    font-size: 14px;
+    transition: all 0.3s ease;
 }
 
 .carousel-inner .carousel-item img {
@@ -499,19 +475,6 @@ form input.form-control {
         padding-top: 82px !important;
     }
 
-    .custom-navbar {
-        padding: 8px 16px;
-    }
-
-    .navbar-collapse {
-        background: rgba(255, 255, 255, 0.96);
-        border: 1px solid var(--pet-border);
-        border-radius: 14px;
-        box-shadow: var(--pet-shadow);
-        margin-top: 10px;
-        padding: 12px;
-    }
-
     .navbar-nav {
         width: 100%;
         text-align: center;
@@ -519,14 +482,6 @@ form input.form-control {
 
     .navbar-nav .nav-item {
         margin-bottom: 10px;
-    }
-
-    #btn-login,
-    #btn-logout,
-    #btn-parceiro,
-    .custom-navbar .btn-adotar {
-        margin-left: 0;
-        width: 100%;
     }
 
     .login-container {


### PR DESCRIPTION
## Summary

Restores the navbar visual styling to the previous calmer version by removing the recent glassy/animated treatment, heavier shadows, rounded pills, and mobile dropdown card styling.

## Impact

The main menu returns to a simpler white bar with the older spacing, link styling, button weights, and shadows while keeping the existing security and local asset changes untouched.

## Validation

- Checked the diff against `origin/Deploy`; only `public/css/styles.css` is changed.
- No automated tests were run because this is a CSS-only visual adjustment.