### PR TITLE
[codex] Remove blue navbar button hover effect

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -196,51 +196,6 @@ body {
     text-decoration: none;
     margin-left: 10px;
     font-size: 14px;
-    position: relative;
-    overflow: hidden;
-    transition: color .25s ease;
-    z-index: 1;
-}
-
-#btn-login::after,
-#btn-logout::after,
-#btn-parceiro::after {
-    content: '';
-    position: absolute;
-    top: -1px;
-    left: -1px;
-    right: -1px;
-    bottom: -1px;
-    background: #0887F2;
-    border-radius: 4px;
-    transform: translateY(103%);
-    transition: transform .45s cubic-bezier(.22,.61,.36,1);
-    will-change: transform;
-    z-index: -1;
-}
-
-#btn-login.is-on,
-#btn-logout.is-on,
-#btn-parceiro.is-on {
-    color: #fff;
-}
-
-#btn-login.is-on::after,
-#btn-logout.is-on::after,
-#btn-parceiro.is-on::after {
-    transform: translateY(0%);
-}
-
-#btn-login.is-off::after,
-#btn-logout.is-off::after,
-#btn-parceiro.is-off::after {
-    transform: translateY(100%);
-}
-
-#btn-login:hover,
-#btn-logout:hover,
-#btn-parceiro:hover {
-    color: #fff;
 }
 
 .custom-navbar .btn-adotar {


### PR DESCRIPTION
## Summary

Removes the animated hover/fill effect from the blue navbar buttons.

## Impact

`Entrar` and `Seja um parceiro` now stay static with white background, blue outline, and blue text instead of changing to the animated filled state.

The orange `Quero Adotar` button is already static on `Deploy` from the previous PR.

## Validation

- Checked the diff; only `public/css/styles.css` is changed.
- No automated tests were run because this is a CSS-only visual tweak.