### PR TITLE
[codex] Use senha as auth password column

### DIFF
--- a/app/Models/Adotante.php
+++ b/app/Models/Adotante.php
@@ -9,6 +9,8 @@ class Adotante extends Authenticatable
 {
     use Notifiable;
 
+    protected $authPasswordName = 'senha';
+
     protected $fillable = [
         'nome_completo',
         'cpf',

--- a/app/Models/Ong.php
+++ b/app/Models/Ong.php
@@ -10,6 +10,7 @@ class Ong extends Authenticatable
     use Notifiable;
 
     protected $table = 'ongs';
+    protected $authPasswordName = 'senha';
 
     protected $fillable = [
         'nome',


### PR DESCRIPTION
## Summary

Configures the authenticated models to use `senha` as the Laravel auth password column name.

## Impact

Laravel 12 can rehash the password after a successful login without trying to update a non-existent `password` column. This fixes the Railway login error:

`SQLSTATE[42S22]: Column not found: 1054 Unknown column 'password' in 'field list'`

## Validation

- Ran `php -l app/Models/Adotante.php`.
- Ran `php -l app/Models/Ong.php`.
- Verified both models return `senha` from `getAuthPasswordName()` via tinker.